### PR TITLE
Added padding and updated font-size

### DIFF
--- a/styles/atom-ide-signature-help.less
+++ b/styles/atom-ide-signature-help.less
@@ -6,7 +6,6 @@
   box-shadow: 0px 1px 4px 0px rgba(0,0,0,1);
   color: @syntax-text-color;
   font-family: Menlo, Monaco, Consolas, monospace;
-  font-size: 80%;
   margin-top: -2px; // Compensate for shadow
   position: relative;
   white-space: normal;
@@ -25,6 +24,8 @@
   display: flex;
   position: relative;
   max-width: 750px;
+  padding-left: 5px;
+  padding-right: 5px;
   transition: background-color 0.15s ease;
   &:hover {
     background-color: mix(@syntax-background-color, @syntax-selection-color, 50%);


### PR DESCRIPTION
This pull request adds 5px padding to the code snippet and removes the hardcoded font size on the description to make the text more readable when using smaller font sizes.

**Before**
<img width="1098" src="https://user-images.githubusercontent.com/499192/54426851-26aae800-4719-11e9-92ed-214673b182dd.png">

**After**
<img width="1098" src="https://user-images.githubusercontent.com/499192/54426981-77badc00-4719-11e9-8472-4b8fd5497ce6.png">

