### PR TITLE
Fixed remove padding from pre tag

### DIFF
--- a/styles/atom-ide-signature-help-marked.less
+++ b/styles/atom-ide-signature-help-marked.less
@@ -11,7 +11,6 @@
   font-size: var(--editor-font-size);
   max-width: 750px;
   overflow: auto;
-  padding: 8px;
   white-space: normal;
 
   // Avoid excess internal padding from markdown blocks.


### PR DESCRIPTION
This is a follow up from #12 which should have included this fix. Sorry for missing it.

[Another reason why we should synchronize the styles.](https://github.com/atom-ide-community/atom-ide-datatip/issues/29)