### PR TITLE
fix: unreliable grammar name source for data tip

### DIFF
--- a/lib/signature-help-manager.js
+++ b/lib/signature-help-manager.js
@@ -236,7 +236,7 @@ module.exports = class SignatureHelpManager {
       // clear last data tip
       this.unmountDataTip();
 
-      const grammar = editor.getGrammar().name.toLowerCase();
+      const grammar = editor.getGrammar().scopeName.toLowerCase();
       const snippetHtml = await this.getSnippetHtml(signature.label, grammar);
       let doc = null;
 

--- a/lib/signature-help-manager.js
+++ b/lib/signature-help-manager.js
@@ -269,7 +269,6 @@ module.exports = class SignatureHelpManager {
       const preElem = document.createElement('pre');
       const codeElem = document.createElement('code');
 
-      codeElem.classList.add(grammarName);
       codeElem.innerText = snippet.replace(regExpLSPPrefix, '');
       preElem.appendChild(codeElem);
 


### PR DESCRIPTION
Fixes data tip snippet creation breaking if grammar name contains spaces.

Issue reference: https://github.com/atom-ide-community/atom-ide-datatip/issues/43
Fix reference: https://github.com/atom-ide-community/atom-ide-datatip/pull/46